### PR TITLE
Fix for bug in rule C which added credit values as strings

### DIFF
--- a/js/classifier.js
+++ b/js/classifier.js
@@ -136,7 +136,7 @@ var portsmouthClassifier = (function() {
 
 			while (creditCount < 100) {
 				tempUnit = join[i];
-				creditCount += tempUnit.credits;
+				creditCount += parseInt(tempUnit.credits);
 				top100.push(tempUnit);
 				i++;
 			}


### PR DESCRIPTION
The value of `creditCount` (the loop condition) was being modified as follows: `0 => 20 => 2010 => leave loop`. Explicitly converting to an integer fixes this.
